### PR TITLE
Fix - Home Page Link Update Year

### DIFF
--- a/frontend/src/components/cards/HomeLeaguesSection.vue
+++ b/frontend/src/components/cards/HomeLeaguesSection.vue
@@ -28,7 +28,7 @@
           title="Fight with the Night"
           description="Thursday Night Orienteering Events Around Edinburgh"
           website="https://euoc.wordpress.com/"
-          alternative-link="/leagues/Fight with the Night 19-20"
+          alternative-link="/leagues/Fight with the Night 20-21"
           :larger="false"
           smaller
         />


### PR DESCRIPTION
Change the Fight with the Night link on homepage to point to this years league