### PR TITLE
Events in Multiple Leagues

### DIFF
--- a/backend/database/event.py
+++ b/backend/database/event.py
@@ -19,6 +19,7 @@ properties = [
     "winsplits",
     "routegadget",
     "userSubmittedResults",
+    "secondaryLeague",
     "uploadKey",
 ]
 
@@ -40,6 +41,9 @@ class Event:
     moreInformation: str
     league: Optional[str]  # from initilization
     leagueName: str
+
+    # results in second league
+    secondaryLeague: Optional[str]
 
     # results
     resultUploaded: bool
@@ -76,6 +80,7 @@ class Event:
             "winsplits": self.winsplits,
             "routegadget": self.routegadget,
             "userSubmittedResults": self.userSubmittedResults,
+            "secondaryLeague": self.secondaryLeague,
         }
 
     def toDictionaryWithUploadKey(self) -> Dict[str, Any]:
@@ -92,6 +97,7 @@ class Event:
             "winsplits": self.winsplits,
             "routegadget": self.routegadget,
             "userSubmittedResults": self.userSubmittedResults,
+            "secondaryLeague": self.secondaryLeague,
             "uploadKey": self.uploadKey,
         }
 
@@ -117,8 +123,9 @@ class Event:
                 winsplits,
                 routegadget,
                 userSubmittedResults,
+                secondaryLeague,
                 uploadKey
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 self.getEventId(),
@@ -133,6 +140,7 @@ class Event:
                 self.winsplits,
                 self.routegadget,
                 self.userSubmittedResults,
+                self.secondaryLeague,
                 generateUploadKey(),
             ),
         )
@@ -152,7 +160,8 @@ class Event:
                 results=%s,
                 winsplits=%s,
                 routegadget=%s,
-                userSubmittedResults=%s
+                userSubmittedResults=%s,
+                secondaryLeague=%s
             WHERE id=%s
             """,
             (
@@ -168,6 +177,7 @@ class Event:
                 self.winsplits,
                 self.routegadget,
                 self.userSubmittedResults,
+                self.secondaryLeague,
                 oldEventId,
             ),
         )
@@ -215,6 +225,7 @@ class Event:
                 winsplits,
                 routegadget,
                 userSubmittedResults,
+                secondaryLeague,
                 uploadKey
             FROM events
             ORDER BY date ASC
@@ -239,6 +250,7 @@ class Event:
                 winsplits,
                 routegadget,
                 userSubmittedResults,
+                secondaryLeague,
                 uploadKey
             FROM events
             WHERE id=%s
@@ -268,6 +280,7 @@ class Event:
                 winsplits,
                 routegadget,
                 userSubmittedResults,
+                secondaryLeague,
                 uploadKey
             FROM events
             WHERE league=%s
@@ -294,6 +307,7 @@ class Event:
                 winsplits,
                 routegadget,
                 userSubmittedResults,
+                secondaryLeague,
                 uploadKey
             FROM events
             WHERE league=%s AND resultUploaded=%s
@@ -320,6 +334,7 @@ class Event:
                 winsplits,
                 routegadget,
                 userSubmittedResults,
+                secondaryLeague,
                 uploadKey
             FROM events
             WHERE resultUploaded = true

--- a/backend/database/event.py
+++ b/backend/database/event.py
@@ -283,7 +283,7 @@ class Event:
                 secondaryLeague,
                 uploadKey
             FROM events
-            WHERE league=%s or secondaryLeague=%s
+            WHERE league=%s OR secondaryLeague=%s
             ORDER BY date ASC
             """,
             (league, league),
@@ -310,10 +310,12 @@ class Event:
                 secondaryLeague,
                 uploadKey
             FROM events
-            WHERE league=%s AND resultUploaded=%s
+            WHERE
+                (league=%s OR secondaryLeague=%s)
+                AND resultUploaded=%s
             ORDER BY date ASC
             """,
-            (league, True),
+            (league, league, True),
         )
         return [Event(result) for result in databaseResult]
 

--- a/backend/database/event.py
+++ b/backend/database/event.py
@@ -283,10 +283,10 @@ class Event:
                 secondaryLeague,
                 uploadKey
             FROM events
-            WHERE league=%s
+            WHERE league=%s or secondaryLeague=%s
             ORDER BY date ASC
             """,
-            (league,),
+            (league, league),
         )
         return [Event(result) for result in databaseResult]
 

--- a/backend/database/initialize.py
+++ b/backend/database/initialize.py
@@ -14,6 +14,7 @@ setupLeagues = """
         dynamicEventResults BOOLEAN,
         leagueScoring TEXT,
         clubRestriction TEXT,
+        subLeagueOf TEXT,
         UNIQUE (name)
     )
 """
@@ -33,6 +34,7 @@ setupEvents = """
         userSubmittedResults BOOLEAN,
         league TEXT NOT NULL,
         uploadKey TEXT,
+        secondaryLeague TEXT,
         UNIQUE (id),
         FOREIGN KEY(league) REFERENCES leagues(name)
         ON UPDATE CASCADE ON DELETE CASCADE

--- a/backend/database/league.py
+++ b/backend/database/league.py
@@ -147,6 +147,11 @@ class League:
             ),
         )
 
+    def getLeagueOfCompetitors(self) -> str:
+        if self.subLeagueOf:
+            return self.subLeagueOf
+        return self.name
+
     @staticmethod
     def getAll() -> List[League]:
         databaseResult = queryWithResults(

--- a/backend/database/league.py
+++ b/backend/database/league.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional
 
 from .database import query, queryWithResult, queryWithResults
 
@@ -16,6 +16,7 @@ properties = [
     "numberOfCountingEvents",
     "dynamicEventResults",
     "clubRestriction",
+    "subLeagueOf",
     "numberOfEvents",
 ]
 
@@ -37,6 +38,9 @@ class League:
     numberOfCountingEvents: int
     dynamicEventResults: bool
     clubRestriction: str
+
+    # contain events from a separate league
+    subLeagueOf: Optional[str]
 
     # Dynamic Properties
     numberOfEvents: int
@@ -68,6 +72,7 @@ class League:
             "dynamicEventResults": self.dynamicEventResults,
             "clubRestriction": self.clubRestriction,
             "numberOfEvents": self.numberOfEvents,
+            "subLeagueOf": self.subLeagueOf,
         }
 
     def create(self) -> None:
@@ -85,8 +90,9 @@ class League:
                 scoringMethod,
                 numberOfCountingEvents,
                 dynamicEventResults,
-                clubRestriction
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                clubRestriction,
+                subLeagueOf
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 self.name,
@@ -101,6 +107,7 @@ class League:
                 self.numberOfCountingEvents,
                 self.dynamicEventResults,
                 self.clubRestriction,
+                self.subLeagueOf,
             ),
         )
 
@@ -119,7 +126,8 @@ class League:
                 scoringMethod=%s,
                 numberOfCountingEvents=%s,
                 dynamicEventResults=%s,
-                clubRestriction=%s
+                clubRestriction=%s,
+                subLeagueOf=%s
             WHERE name=%s""",
             (
                 self.name,
@@ -134,6 +142,7 @@ class League:
                 self.numberOfCountingEvents,
                 self.dynamicEventResults,
                 self.clubRestriction,
+                self.subLeagueOf,
                 oldName,
             ),
         )
@@ -155,6 +164,7 @@ class League:
                 leagues.numberOfCountingEvents,
                 leagues.dynamicEventResults,
                 leagues.clubRestriction,
+                leagues.subLeagueOf,
                 COUNT(events.id)
             FROM leagues
             LEFT JOIN events ON leagues.name=events.league
@@ -181,6 +191,7 @@ class League:
                 leagues.numberOfCountingEvents,
                 leagues.dynamicEventResults,
                 leagues.clubRestriction,
+                leagues.subLeagueOf,
                 COUNT(events.id)
             FROM leagues
             LEFT JOIN events ON leagues.name=events.league

--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -46,6 +46,11 @@ eventModel = Model(
         "userSubmittedResults": fields.Boolean(
             description="Allow Users to Submit Results", default=False
         ),
+        "secondaryLeague": fields.String(
+            description="Name of a Second League the Results Are to Be Used In",
+            default=None,
+            example="Sprintelope",
+        ),
     },
 )
 

--- a/backend/models/league.py
+++ b/backend/models/league.py
@@ -53,5 +53,10 @@ leagueModel = Model(
         "numberOfEvents": fields.Integer(
             description="Number of Events in the League", readonly=True, example=7
         ),
+        "subLeagueOf": fields.String(
+            description="League which can inherit events from, must have the same Scoring System and Courses",
+            default=None,
+            example="Sprintelope",
+        ),
     },
 )

--- a/backend/routes/league.py
+++ b/backend/routes/league.py
@@ -131,7 +131,7 @@ class LeagueOverallResultsRoute(Resource):
             events = Event.getByLeagueWithResults(name)
             results = [
                 result.toDictionary(league, events)
-                for result in LeagueResult.getByLeague(name)
+                for result in LeagueResult.getByLeague(name, league.subLeagueOf)
             ]
             sortedResults = sortByTotalPoints(results)
             return assignPosition(sortedResults)
@@ -150,9 +150,10 @@ class LeagueCourseResultsRoute(Resource):
         try:
             league = League.getByName(name)
             events = Event.getByLeagueWithResults(name)
+            print([event.name for event in events])
             results = [
                 result.toDictionary(league, events)
-                for result in LeagueResult.getByCourse(name, course)
+                for result in LeagueResult.getByCourse(name, league.subLeagueOf, course)
             ]
             sortedResults = sortByTotalPoints(results)
             return assignPosition(sortedResults)

--- a/backend/routes/league.py
+++ b/backend/routes/league.py
@@ -186,6 +186,10 @@ class LeagueCompetitorsRoute(Resource):
     @api.response(500, "Problem Connecting to the Database")
     def get(self, name):
         try:
-            return [event.toDictionary() for event in Competitor.getByLeague(name)]
+            league = League.getByName(name)
+            leagueOfCompetitors = league.getLeagueOfCompetitors()
+            competitors = Competitor.getByLeague(leagueOfCompetitors)
+
+            return [event.toDictionary() for event in competitors]
         except:
             return [], 500

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -102,10 +102,11 @@ class UploadResultRoute(Resource):
             )
 
         league = event.getLeague()
+        leagueOfCompetitors = league.getLeagueOfCompetitors()
 
         try:
             competitor = Competitor.getByNameCourseAndLeague(
-                data["name"], data["course"], league.name
+                data["name"], data["course"], leagueOfCompetitors
             )
             if not competitor:
                 competitor = Competitor(
@@ -114,7 +115,7 @@ class UploadResultRoute(Resource):
                         "ageClass": "",
                         "club": "",
                         "course": data["course"],
-                        "league": league.name,
+                        "league": leagueOfCompetitors,
                     }
                 )
                 competitorID = competitor.create()

--- a/backend/utils/matchCompetitor.py
+++ b/backend/utils/matchCompetitor.py
@@ -9,7 +9,8 @@ ResultDict = Dict[str, Any]
 def matchResultsToCompetitors(
     results: List[ResultDict], league: League
 ) -> List[ResultDict]:
-    competitors = Competitor.getByLeague(league.name)
+    leagueOfCompetitors = league.getLeagueOfCompetitors()
+    competitors = Competitor.getByLeague(leagueOfCompetitors)
 
     return [
         {**result, "competitor": matchResultToCompetitor(result, competitors, league)}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7177,9 +7177,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.0.0-beta.58",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.0.0-beta.58.tgz",
-      "integrity": "sha512-zMoUL4plXNrfQJn8vQCcaYlK7wmNO9WFO2keBb8b44FZWlSP4NPRm6rUQPp1gmDMEflOO8HFycXfrZ29VxDf/g==",
+      "version": "2.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.0.0-beta.59.tgz",
+      "integrity": "sha512-tlxEPFpVI1wV+vk+t/ypwBZfNmxKcorok8YF82MrQIqCDeRXnHvp33oWPIsRrO0V7UdnnlkKQOJJiIi3AIUFOA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.8.34",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-workbox": "^6.1.1",
     "tailwindcss": "^2.0.2",
     "typescript": "^4.1.3",
-    "vite": "^2.0.0-beta.58"
+    "vite": "^2.0.0-beta.59"
   },
   "browserslist": [
     "defaults",

--- a/frontend/src/components/cards/EventCardSmall.vue
+++ b/frontend/src/components/cards/EventCardSmall.vue
@@ -3,7 +3,7 @@
     class="flex flex-col items-center justify-around col-span-2 px-4 pt-6 pb-4 text-center bg-white shadow-md md:px-2 md:pb-3 md:col-span-1 xl:px-4 rounded-shape-xl"
   >
     <h3
-      class="text-xs font-bold leading-tight tracking-wider uppercase truncate font-heading text-main-600 md:tracking-wide"
+      class="text-xs font-bold leading-tight tracking-wider uppercase truncate font-heading text-main-700 md:tracking-wide"
     >
       {{ event.league }}
     </h3>

--- a/frontend/src/components/cards/EventOverviewCard.vue
+++ b/frontend/src/components/cards/EventOverviewCard.vue
@@ -37,14 +37,26 @@
       </h3>
 
       <div
-        v-if="showFullDetails && (event.moreInformation || event.website)"
+        v-if="
+          showFullDetails &&
+          (event.moreInformation ||
+            event.website ||
+            event?.league !== league?.name)
+        "
         class="mt-2 mb-4 text-base leading-snug"
       >
-        <p v-if="event.moreInformation" class="mb-1 text-gray-500 break-words">
+        <p
+          v-if="event?.league !== league?.name"
+          class="mb-1 text-gray-600 break-words"
+        >
+          This event is also in the {{ event.league }} league.
+        </p>
+
+        <p v-if="event.moreInformation" class="mb-1 text-gray-600 break-words">
           {{ event.moreInformation }}
         </p>
 
-        <p v-if="event.website" class="text-gray-500">
+        <p v-if="event.website" class="text-gray-600">
           More Information can be found on the
           <a
             :href="event.website"

--- a/frontend/src/types/Event.d.ts
+++ b/frontend/src/types/Event.d.ts
@@ -13,4 +13,6 @@ interface LeagueEvent {
   routegadget: string
   userSubmittedResults: boolean
   uploadKey?: string
+
+  secondaryLeague?: string
 }

--- a/frontend/src/types/League.d.ts
+++ b/frontend/src/types/League.d.ts
@@ -6,6 +6,7 @@ interface LeagueBase {
   coordinator: string
   website: string
 
+  subLeagueOf?: string
   courses: string[] | string
   leagueScoring?: string
   scoringMethod: string

--- a/frontend/src/views/admin/Competitors.vue
+++ b/frontend/src/views/admin/Competitors.vue
@@ -132,7 +132,6 @@ import {
   SortablePropertiesCompetitor as SortableProperties,
 } from '../../scripts/sort'
 
-const router = useRouter()
 const route = useRoute()
 
 import { getLeagueCompetitors } from '../../api/competitors'
@@ -144,9 +143,11 @@ const rawCompetitors = ref<Competitor[]>([])
 const getData = async () => {
   const routeParamsLeague = toSingleString(route.params.league)
 
-  loading.value = true
-  rawCompetitors.value = (await getLeagueCompetitors(routeParamsLeague)) ?? []
-  loading.value = false
+  if (routeParamsLeague) {
+    loading.value = true
+    rawCompetitors.value = (await getLeagueCompetitors(routeParamsLeague)) ?? []
+    loading.value = false
+  }
 }
 
 const competitors = computed(() =>
@@ -156,7 +157,7 @@ const competitors = computed(() =>
 watch(route, getData, { immediate: true })
 
 /* Sorting */
-const sortPreferences = ref<SortPreferences>({
+const sortPreferences = ref<SortPreferencesCompetitor>({
   ascending: false,
   by: SortableProperties.name,
 })

--- a/frontend/src/views/admin/EventForm.vue
+++ b/frontend/src/views/admin/EventForm.vue
@@ -15,8 +15,9 @@
       <TextInput v-model.trim="event.name" label="Name:" />
       <TextInput
         v-model.trim="event.date"
-        label="Date: (YYYY-MM-DD)"
+        label="Date:"
         class="mt-4"
+        type="date"
       />
       <TextInput
         v-model.trim="event.organiser"

--- a/frontend/src/views/admin/EventForm.vue
+++ b/frontend/src/views/admin/EventForm.vue
@@ -59,6 +59,13 @@
         label="More Information:"
         class="mt-4"
       />
+      <DropdownInput
+        v-model="event.secondaryLeague"
+        :list="subLeagues"
+        :include-blank="true"
+        label="Secondary League:"
+        class="mt-4"
+      />
       <CheckboxInput
         v-model="event.userSubmittedResults"
         label="Allow Users to Submit Results"
@@ -110,6 +117,7 @@ const event = ref<LeagueEvent>({
   routegadget: '',
   userSubmittedResults: false,
   league: '',
+  secondaryLeague: '',
 })
 
 const refreshDetails = async () => {
@@ -123,6 +131,7 @@ const refreshDetails = async () => {
     loading.value = true
     await getEvent(routeParamsId).then((data) => {
       if (data) event.value = data
+      if (!data?.secondaryLeague) event.value.secondaryLeague = ''
     })
     loading.value = false
   }
@@ -163,6 +172,12 @@ const submit = () =>
 
 const title = computed(() =>
   route.path.includes('/edit') ? 'Edit Event' : 'Create Event'
+)
+
+const subLeagues = computed(() =>
+  leagues.value
+    .filter((league) => league.subLeagueOf === event.value.league)
+    .map((league) => league.name)
 )
 
 watch(route, refreshDetails, { immediate: true })

--- a/frontend/src/views/admin/LeagueForm.vue
+++ b/frontend/src/views/admin/LeagueForm.vue
@@ -97,6 +97,13 @@
         label="Courses: (Comma Separated)"
         class="mt-4"
       />
+      <DropdownInput
+        v-model="league.subLeagueOf"
+        :list="leaguesSuitableForSubLeague"
+        :include-blank="true"
+        label="Sub League Of:"
+        class="mt-4"
+      />
       <TextareaInput
         v-model.trim="league.moreInformation"
         label="More Information:"
@@ -125,6 +132,7 @@ import { toSingleString } from '../../scripts/typeHelpers'
 
 import {
   getLeague,
+  getLeagues,
   createLeague as apiCreateLeague,
   updateLeague as apiUpdateLeague,
 } from '../../api/leagues'
@@ -134,6 +142,7 @@ const router = useRouter()
 const route = useRoute()
 
 const loading = ref(true)
+const leagues = ref<League[]>([])
 const league = ref<LeagueForm>({
   courses: '',
   coordinator: '',
@@ -147,10 +156,15 @@ const league = ref<LeagueForm>({
   year: 2000,
   leagueScoring: 'course',
   clubRestriction: '',
+  subLeagueOf: '',
 })
 
 const refreshDetails = async () => {
   const routeParamsName = toSingleString(route.params.name)
+
+  getLeagues().then((data) => {
+    leagues.value = data ?? []
+  })
 
   loading.value = true
   if (routeParamsName)
@@ -209,6 +223,12 @@ const submit = () =>
 
 const title = computed(() =>
   route.path.includes('/edit') ? 'Edit League' : 'Create League'
+)
+
+const leaguesSuitableForSubLeague = computed(() =>
+  leagues.value
+    .filter((l) => l.scoringMethod === league.value.scoringMethod)
+    .map((league) => league.name)
 )
 
 watch(route, refreshDetails, { immediate: true })


### PR DESCRIPTION
Add the ability for events to be viewed in multiple different leagues.

Due to the architecture of Munro there are some limitations:
- Each league can only share events with one other league (set as the "super"/"master" league)
- Both leagues must have the same scoring system
- The results are linked to competitors in the "super"/"master" league, no competitors are created in the sub-league
- Dynamic Results (Average/ Maximum calculated results) cannot be used in either league 